### PR TITLE
Somente valida o CEP, se houver conteúdo

### DIFF
--- a/app/code/community/Storm/Correios/Model/Carrier/Shipping.php
+++ b/app/code/community/Storm/Correios/Model/Carrier/Shipping.php
@@ -126,19 +126,20 @@ class Storm_Correios_Model_Carrier_Shipping extends Mage_Shipping_Model_Carrier_
      */
     public function isValid(Mage_Shipping_Model_Rate_Request $request)
     {
+        $helper = $this->_getHelper();
+
         if (!extension_loaded('soap')) {
-            throw new Mage_Shipping_Exception($this->_getHelper()->__('You must to install PHP Soap extension to use shipping method Correios.'));
-            return false;
+            throw new Mage_Shipping_Exception($helper->__('You must to install PHP Soap extension to use shipping method Correios.'));
         }
 
-        if (!$this->_getHelper()->isValidPostcode($request->getDestPostcode())) {
-            throw new Mage_Shipping_Exception($this->_getHelper()->__('Please, enter the postcode correctly.'));
-            return false;
+        $postCode = $request->getPostcode();
+
+        if ($postCode && !$helper->isValidPostcode($postCode)) {
+            throw new Mage_Shipping_Exception($helper->__('Please, enter the postcode correctly.'));
         }
 
         if ($request->getPackageWeight() > self::PACKAGE_WEIGHT_MAX) {
-            throw new Mage_Shipping_Exception($this->_getHelper()->__('The package weight exceeds the weight limit.'));
-            return false;
+            throw new Mage_Shipping_Exception($helper->__('The package weight exceeds the weight limit.'));
         }
 
         return true;


### PR DESCRIPTION
Resolve o issue willstorm/correios#25

O módulo aplicava validação em CEP, mesmo quando o usuário, cliente, não o preenchia. Dessa forma, adicionei uma verificação para checar se tal informação existe.